### PR TITLE
recipes-poky/base-files: Remove entry from fstab

### DIFF
--- a/recipes-poky/base-files/base-files/fstab
+++ b/recipes-poky/base-files/base-files/fstab
@@ -10,7 +10,6 @@ tmpfs                /var/volatile        tmpfs      nosuid,nodev,noexec   0  0
 tmpfs                /tmp                 tmpfs      defaults              0  0
 
 LABEL=boot           /boot                vfat       umask=0077            0  1
-LABEL=gyroidos       /mnt                 ext4       nosuid,nodev,noexec   0  0
 
 /mnt/modules.img     /lib/modules         squashfs   loop,nosuid,nodev,noexec 0  0
 /mnt/firmware.img    /lib/firmware        squashfs   loop,nosuid,nodev,noexec 0  0


### PR DESCRIPTION
This PR removes the entry 'gyroidos' from the fstab as the label is only used during initial formatting and debugging builds on platforms without a TPM. There, the data partiion is explicitly mountet by LABEL in