### PR TITLE
recipes-support/opensc: Add support for RSA public key encoded with i…

### DIFF
--- a/recipes-support/opensc/opensc/0001-Add-support-for-RSA-public-key-encoded-with-id-RSASS.patch
+++ b/recipes-support/opensc/opensc/0001-Add-support-for-RSA-public-key-encoded-with-id-RSASS.patch
@@ -1,0 +1,28 @@
+From d0a884a91508a064154790b1c18440f4937e6812 Mon Sep 17 00:00:00 2001
+From: David Sonntag <dsonntag@blackned.de>
+Date: Wed, 26 Feb 2025 17:43:37 +0100
+Subject: [PATCH] Add-support-for-RSA-public-key-encoded-with-id-RSASS
+
+---
+ src/libopensc/pkcs15-algo.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/libopensc/pkcs15-algo.c b/src/libopensc/pkcs15-algo.c
+index 39539b365..fa5e717c4 100644
+--- a/src/libopensc/pkcs15-algo.c
++++ b/src/libopensc/pkcs15-algo.c
+@@ -361,8 +361,9 @@ static struct sc_asn1_pkcs15_algorithm_info algorithm_table[] = {
+ #ifdef SC_ALGORITHM_DSA
+ 	{ SC_ALGORITHM_DSA, {{ 1, 2, 840, 10040, 4, 3, -1}}, NULL, NULL, NULL },
+ #endif
+-#ifdef SC_ALGORITHM_RSA /* really rsaEncryption */
+-	{ SC_ALGORITHM_RSA, {{ 1, 2, 840, 113549, 1, 1, 1, -1}}, NULL, NULL, NULL },
++#ifdef SC_ALGORITHM_RSA /* really rsaEncryption and id-RSASSA-PSS */
++		{SC_ALGORITHM_RSA, {{ 1, 2, 840, 113549, 1, 1, 1, -1}}, NULL, NULL, NULL },
++		{SC_ALGORITHM_RSA, {{ 1, 2, 840, 113549, 1, 1, 10, -1}}, NULL, NULL, NULL },
+ #endif
+ #ifdef SC_ALGORITHM_DH
+ 	{ SC_ALGORITHM_DH, {{ 1, 2, 840, 10046, 2, 1, -1}}, NULL, NULL, NULL },
+-- 
+2.39.5
+

--- a/recipes-support/opensc/opensc_0.22.0.bbappend
+++ b/recipes-support/opensc/opensc_0.22.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:append := "${THISDIR}/${PN}:"
+SRC_URI:append = "file://0001-Add-support-for-RSA-public-key-encoded-with-id-RSASS.patch"


### PR DESCRIPTION
…d-RSASSA-PSS

The SPKI for a RSA public key can contain PSS restriction in the algorithm info.

In that case, the algorithm identifier is id-RSASSA-PSS (1.2.840.113549.1.1.10) with PSS restrictions in algorithm parameter.

This patch adds the id-RSASSA-PSS OID, but does not further decode PSS restrictions.