### PR TITLE
recipes-initscripts: cml-boot-script: Change scan_devices sleep timer

### DIFF
--- a/recipes-initscripts/cml-boot/files/cml-boot-script.stub
+++ b/recipes-initscripts/cml-boot/files/cml-boot-script.stub
@@ -1,9 +1,8 @@
 function scan_devices {
 	udevadm trigger --type=subsystems --action=add
-	sleep 2
 	udevadm settle
+	sleep 4
 	udevadm trigger --type=devices --action=add
-	sleep 2
 	udevadm settle
 }
 


### PR DESCRIPTION
Booting GyroidOS in VirtualBox with TPM2.0 enabled led to the network interfaces to disappear after the 2º boot and having the UI behaving abnormally in the VirtualBox window. Collapsing both 2 second sleeps into one 4 second sleep before 'udevadm trigger --type=devices' and after the first 'udevadm settle' fixed the issue.