### PR TITLE
Reduce size of Initramfs in debug builds

### DIFF
--- a/conf/distro/cml-base.conf
+++ b/conf/distro/cml-base.conf
@@ -7,3 +7,5 @@ DISTROOVERRIDES = "poky-tiny:cml-base"
 TARGET_VENDOR = "-gyroidos"
 
 INITRAMFS_MAXSIZE = '${@oe.utils.vartrue('DEVELOPMENT_BUILD', "350000", "35000", d)}'
+
+PACKAGECONFIG:remove:pn-gdb = "python"

--- a/images/gyroidos-cml-initramfs.bb
+++ b/images/gyroidos-cml-initramfs.bb
@@ -122,10 +122,19 @@ cleanup_boot () {
 	rm -f ${IMAGE_ROOTFS}/boot/*
 }
 
+cleanup_debug_files () {
+        rm -f ${IMAGE_ROOTFS}/usr/lib/.debug/libprotobuf-lite.so.*
+        rm -f ${IMAGE_ROOTFS}/usr/lib/.debug/libprotobuf.so.*
+        rm -f ${IMAGE_ROOTFS}/usr/lib/.debug/libprotoc.so.*
+}
+
 ROOTFS_POSTPROCESS_COMMAND:append = " update_modules_dep; "
 ROOTFS_POSTPROCESS_COMMAND:append = " update_hostname; "
 ROOTFS_POSTPROCESS_COMMAND:append = " cleanup_boot; "
 ROOTFS_POSTPROCESS_COMMAND:append = " install_ima_cert; "
+
+# protobuf debug symbols are huge >100M, remove this from initramfs
+ROOTFS_POSTPROCESS_COMMAND:append = '${@oe.utils.vartrue('DEVELOPMENT_BUILD', " cleanup_debug_files; ", "",d)}'
 
 # For debug purpose allow login if debug-tweaks is set in local.conf
 ROOTFS_POSTPROCESS_COMMAND:append = '${@oe.utils.vartrue('DEVELOPMENT_BUILD', " update_tabs ; ", " update_tabs_release ; ",d)}'


### PR DESCRIPTION
Removed python dependency in scarthgap builds and protobuf debug symbols